### PR TITLE
Fix "make test" outside src/test + boost compat.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 install:
     - true # if test "$WHAT" = "normal"; then . fc-solve/scripts/ci-install-stage.bash ; elif test "$WHAT" = "buildproc"; then . fc-solve/scripts/ci-docker-test--install.bash ; fi
 script:
-    - if test "$WHAT" = "normal"; then cmake -DCMAKE_BUILD_TYPE=Debug -Bcmake-build-debug -H. && cmake --build cmake-build-debug && cd src/test && ../../unit-tests-debug; fi
+    - if test "$WHAT" = "normal"; then cmake -DCMAKE_BUILD_TYPE=Debug -Bcmake-build-debug -H. && cmake --build cmake-build-debug && (cd src/test && ../../unit-tests-debug) && (cd cmake-build-debug && make test); fi
 cache:
     ccache: true
     directories:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ include_directories(lib/rapidjson)
 ## Boost setup ################################################################
 ###############################################################################
 
-set(Boost_USE_STATIC_LIBS ON)
+# set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 
@@ -196,8 +196,8 @@ target_link_libraries(unit_tests gtest_main ${Boost_LIBRARIES})
 
 ENABLE_TESTING()
 ADD_TEST(NAME unit_tests
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-        COMMAND unit_tests)
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/test"
+        COMMAND "${CMAKE_CURRENT_BINARY_DIR}/bin/unit_tests")
 
 ###############################################################################
 ## packaging ##################################################################


### PR DESCRIPTION
[Below message by @shlomif when creating [original PR](https://github.com/thecharlesblake/Solvitaire/pull/125)]

Fedora x86-64 and Mageia do not have static boost libraries.

--

I hereby disclaim any implicit or explicit ownership of my changes in this
changeset, and put them under a multiple licence consisting of your choice of
one of more of:

- The CC0 / Public Domain - https://creativecommons.org/choose/zero/ .

- The MIT / Expat license - https://en.wikipedia.org/wiki/MIT_License

- The default licence of your project

- The https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License - version
2.1 or higher

- The https://en.wikipedia.org/wiki/GNU_General_Public_License - version 2 or
higher

- Any licence in the 2018-Aug-27 popular licenses list of
https://opensource.org/licenses

- The https://en.wikipedia.org/wiki/Apache_License version 2.0 or later

- The https://en.wikipedia.org/wiki/Artistic_License version 2.0 or later

- The https://en.wikipedia.org/wiki/ISC_license

- The https://opensource.org/licenses/BSD-2-Clause

Crediting me will be nice, but not mandatory, and you can change the licence
of the project without needing my permission.